### PR TITLE
Out of range floppa id static instead of random

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -10,6 +10,7 @@ use serenity::model::{
 };
 use serenity::prelude::TypeMapKey;
 use std::sync::Arc;
+use std::cmp;
 
 use Blacklist::*;
 
@@ -240,9 +241,10 @@ pub async fn get_floppa(ctx: &Context, n: Option<u32>) -> Option<String> {
         )
         .await
         .ok()?;
-
-    let floppa_id = if n.is_some() && ids.contains(&n.unwrap()) {
-        n.unwrap()
+    
+    
+    let floppa_id = if n.is_some() && ids.len() > 0 { 
+        ids.get(cmp::max(0, n.unwrap() as usize % ids.len()))
     } else {
         choose_from_ids(ids)
     };

--- a/src/database.rs
+++ b/src/database.rs
@@ -244,7 +244,7 @@ pub async fn get_floppa(ctx: &Context, n: Option<u32>) -> Option<String> {
     
     
     let floppa_id = if n.is_some() && ids.len() > 0 { 
-        *ids.get(cmp::max(0, n.unwrap() as usize % ids.len())).unwrap()
+        *ids.get(cmp::max(0, (n.unwrap() - 1) as usize % ids.len())).unwrap()
     } else {
         choose_from_ids(ids)
     };

--- a/src/database.rs
+++ b/src/database.rs
@@ -244,7 +244,7 @@ pub async fn get_floppa(ctx: &Context, n: Option<u32>) -> Option<String> {
     
     
     let floppa_id = if n.is_some() && ids.len() > 0 { 
-        ids.get(cmp::max(0, n.unwrap() as usize % ids.len())).unwrap()
+        *ids.get(cmp::max(0, n.unwrap() as usize % ids.len())).unwrap()
     } else {
         choose_from_ids(ids)
     };

--- a/src/database.rs
+++ b/src/database.rs
@@ -245,7 +245,7 @@ pub async fn get_floppa(ctx: &Context, n: Option<u32>) -> Option<String> {
     
     let floppa_id = if n.is_some() && ids.len() > 0 { 
         if ids.contains(&n.unwrap()) {
-            n
+            n.unwrap()
         } else {
             *ids.get(cmp::max(0, (n.unwrap() - 1) as usize % ids.len())).unwrap()
         }

--- a/src/database.rs
+++ b/src/database.rs
@@ -244,7 +244,7 @@ pub async fn get_floppa(ctx: &Context, n: Option<u32>) -> Option<String> {
     
     
     let floppa_id = if n.is_some() && ids.len() > 0 { 
-        ids.get(cmp::max(0, n.unwrap() as usize % ids.len()))
+        ids.get(cmp::max(0, n.unwrap() as usize % ids.len())).unwrap()
     } else {
         choose_from_ids(ids)
     };

--- a/src/database.rs
+++ b/src/database.rs
@@ -244,7 +244,11 @@ pub async fn get_floppa(ctx: &Context, n: Option<u32>) -> Option<String> {
     
     
     let floppa_id = if n.is_some() && ids.len() > 0 { 
-        *ids.get(cmp::max(0, (n.unwrap() - 1) as usize % ids.len())).unwrap()
+        if ids.contains(&n.unwrap()) {
+            n
+        } else {
+            *ids.get(cmp::max(0, (n.unwrap() - 1) as usize % ids.len())).unwrap()
+        }
     } else {
         choose_from_ids(ids)
     };


### PR DESCRIPTION
This commit should make specified non-existing id's always point to the same picture (as long as the database is not updated)
Example: 
Database contains 50 pictures
`!floppa 51` returns the same as `!floppa 1` (regardless of ids actually stored in database)